### PR TITLE
replace name in kenwood-ts480.lua protocol file

### DIFF
--- a/protocol/kenwood-ts480.lua
+++ b/protocol/kenwood-ts480.lua
@@ -86,7 +86,7 @@ local function getMode(driver)
 end
 
 return {
-	name = 'trusdx',
+	name = 'Kenwood TS-480 CAT protocol',
 	capabilities = {	-- driver specific
 		frequency = true,
 		mode = true,


### PR DESCRIPTION
was listing the trx name, not the protocol name