### PR TITLE
Show error message if avahi handler isn't available

### DIFF
--- a/sbin/trxd/websocket-listener.c
+++ b/sbin/trxd/websocket-listener.c
@@ -194,7 +194,10 @@ websocket_listener(void *arg)
 
 	if (t->announce) {
 		/* Create the Avahi handler thread */
-		pthread_create(&t->announcer, NULL, avahi_handler, t);
+		if (!pthread_create(&t->announcer, NULL, avahi_handler, t)) {
+			syslog(LOG_ERR, "websocket-listener: can't create avahi handler thread. handler missing?");
+			exit(1);
+		}
 	}
 
 	/* Wait for connections as long as websocket_listener runs */


### PR DESCRIPTION
Let's start with something small :)

During my first deployment I noticed something. 
The `announce` parameter in the `trxd.yaml`, which is `true` per default causes the trxd.service to fail without any additional information. I took me a few moments until I noticed that announcement is enabled. A error message would have been nice which points me to the right direction. 

This PR, my first one 👍 , brings a little error message to the Syslog.